### PR TITLE
Fix compilation error under Xcode 7 (clang-700.0.53)

### DIFF
--- a/include/xhyve/support/uuid.h
+++ b/include/xhyve/support/uuid.h
@@ -76,7 +76,7 @@ uuid_create_nil(uuid_t *u, uint32_t *status)
 }
 
 static void
-uuid_enc_le(void *buf, const uuid_t *uuid)
+uuid_enc_le(void *buf, uuid_t *uuid)
 {
 	uuid_internal_t *u = (uuid_internal_t *) ((void *) uuid);
 	uint8_t *p = buf;


### PR DESCRIPTION
Fixes:

    In file included from src/smbiostbl.c:37:
    include/xhyve/support/uuid.h:81:53: error: cast from 'unsigned char const (*)[16]' to 'void *' drops const qualifier [-Werror,-Wcast-qual]
            uuid_internal_t *u = (uuid_internal_t *) ((void *) uuid);
                                                           ^
    1 error generated.
    make: *** [build/smbiostbl.o] Error 1
