### PR TITLE
vbsc_ident buffer accessed out of bounds

### DIFF
--- a/src/pci_ahci.c
+++ b/src/pci_ahci.c
@@ -131,12 +131,13 @@ struct ahci_ioreq {
 	int more;
 };
 
+#define AHCI_PORT_IDENT 20 + 1
 struct ahci_port {
 	struct blockif_ctxt *bctx;
 	struct pci_ahci_softc *pr_sc;
 	uint8_t *cmd_lst;
 	uint8_t *rfis;
-	char ident[20 + 1];
+	char ident[AHCI_PORT_IDENT];
 	int atapi;
 	int reset;
 	int waitforclear;
@@ -2320,7 +2321,7 @@ pci_ahci_init(struct pci_devinst *pi, char *opts, int atapi)
 	MD5Init(&mdctx);
 	MD5Update(&mdctx, opts, ((unsigned int) strlen(opts)));
 	MD5Final(digest, &mdctx);	
-	sprintf(sc->port[0].ident, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
+	snprintf(sc->port[0].ident, AHCI_PORT_IDENT, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
 	    digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]);
 
 	/*

--- a/src/pci_virtio_block.c
+++ b/src/pci_virtio_block.c
@@ -56,7 +56,7 @@
 #define VTBLK_S_IOERR 1
 #define	VTBLK_S_UNSUPP 2
 
-#define	VTBLK_BLK_ID_BYTES 20
+#define	VTBLK_BLK_ID_BYTES 20 + 1
 
 /* Capability bits */
 #define	VTBLK_F_SEG_MAX (1 << 2) /* Maximum request segments */
@@ -362,7 +362,7 @@ pci_vtblk_init(struct pci_devinst *pi, char *opts)
 	MD5Init(&mdctx);
 	MD5Update(&mdctx, opts, ((unsigned) strlen(opts)));
 	MD5Final(digest, &mdctx);	
-	sprintf(sc->vbsc_ident, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
+	snprintf(sc->vbsc_ident, VTBLK_BLK_ID_BYTES, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
 	    digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]);
 
 	/* setup virtio block config space */


### PR DESCRIPTION
Adopt src/pci_ahci.c logic

struct ahci_port {
    ...
    char ident[20 + 1];
    ...
}

as they both hold the MD5 sum. Also while at it start using snprintf.

Signed-off-by: S.Çağlar Onur <caglar@10ur.org>