### PR TITLE
Fix a warning message about pci host bridge

### DIFF
--- a/src/pci_hostbridge.c
+++ b/src/pci_hostbridge.c
@@ -36,7 +36,7 @@ pci_hostbridge_init(struct pci_devinst *pi, UNUSED char *opts)
 	/* config space */
 	pci_set_cfgdata16(pi, PCIR_VENDOR, 0x1275);	/* NetApp */
 	pci_set_cfgdata16(pi, PCIR_DEVICE, 0x1275);	/* NetApp */
-	pci_set_cfgdata8(pi, PCIR_HDRTYPE, PCIM_HDRTYPE_BRIDGE);
+	pci_set_cfgdata8(pi, PCIR_HDRTYPE, PCIM_HDRTYPE_NORMAL);
 	pci_set_cfgdata8(pi, PCIR_CLASS, PCIC_BRIDGE);
 	pci_set_cfgdata8(pi, PCIR_SUBCLASS, PCIS_BRIDGE_HOST);
 


### PR DESCRIPTION
I got a warning message as below. And I found it has been patched on upstream.

```
pci 0000:00:00.0: ignoring class 0x060000 (doesn't match header type 01)
```

Cf.)
- https://github.com/freebsd/freebsd/commit/ab4eab33be088c74ec511e42660e0a55e6334a5f
- http://lists.freebsd.org/pipermail/freebsd-virtualization/2015-June/003643.html
- http://lists.freebsd.org/pipermail/freebsd-virtualization/2015-June/003645.html