### PR TITLE
build: pass BHYVE_ASL_COMPILER through cmd

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -6,9 +6,6 @@
 # [XHYVE_CONFIG_STATS]  VMM event profiler                                    #
 ###############################################################################
 
-DEFINES := \
-  -DXHYVE_CONFIG_ASSERT
-
 ###############################################################################
 # Toolchain                                                                   #
 ###############################################################################
@@ -19,8 +16,22 @@ LD := clang
 STRIP := strip
 DSYM := dsymutil
 
+# Default to /usr/sbin/iasl for historic reasons
+IASL ?= $(shell which iasl)
+ifeq ($(IASL),)
+IASL = /usr/sbin/iasl
+endif
+
 ENV := \
   LANG=en_US.US-ASCII
+
+###############################################################################
+# DEFINES                                                                     #
+###############################################################################
+
+DEFINES := \
+	-DXHYVE_CONFIG_ASSERT \
+	-DBHYVE_ASL_COMPILER=$(IASL)
 
 ###############################################################################
 # CFLAGS                                                                      #

--- a/src/acpi.c
+++ b/src/acpi.c
@@ -82,7 +82,6 @@
 
 #define	BHYVE_ASL_TEMPLATE	"bhyve.XXXXXXX"
 #define BHYVE_ASL_SUFFIX	".aml"
-#define BHYVE_ASL_COMPILER	"/usr/sbin/iasl"
 
 static int basl_keep_temps;
 static int basl_verbose_iasl;
@@ -445,7 +444,7 @@ basl_fwrite_fadt(FILE *fp)
 	EFPRINTF(fp, "[0008]\t\tAddress : 00000000%08X\n",
 	    PM1A_EVT_ADDR);
 	EFPRINTF(fp, "\n");
-	
+
 	EFPRINTF(fp,
 	    "[0012]\t\tPM1B Event Block : [Generic Address Structure]\n");
 	EFPRINTF(fp, "[0001]\t\tSpace ID : 01 [SystemIO]\n");
@@ -650,7 +649,7 @@ basl_fwrite_facs(FILE *fp)
 	EFFLUSH(fp);
 
 	return (0);
-	
+
 err_exit:
 	return (errno);
 }
@@ -853,7 +852,7 @@ basl_load(int fd, uint64_t off)
 
 	if (fstat(fd, &sb) < 0)
 		return (errno);
-		
+
 	gaddr = paddr_guest2host(basl_acpi_base + off, ((size_t) sb.st_size));
 	if (gaddr == NULL)
 		return (EFAULT);
@@ -889,7 +888,7 @@ basl_compile(int (*fwrite_section)(FILE *), uint64_t offset)
 			fmt = basl_verbose_iasl ?
 				"%s -p %s %s" :
 				"/bin/sh -c \"%s -p %s %s\" 1> /dev/null";
-				
+
 			snprintf(iaslbuf, sizeof(iaslbuf),
 				 fmt,
 				 BHYVE_ASL_COMPILER,
@@ -919,9 +918,9 @@ basl_make_templates(void)
 	int len;
 
 	err = 0;
-	
+
 	/*
-	 * 
+	 *
 	 */
 	if ((tmpdir = getenv("BHYVE_TMPDIR")) == NULL || *tmpdir == '\0' ||
 	    (tmpdir = getenv("TMPDIR")) == NULL || *tmpdir == '\0') {


### PR DESCRIPTION
BHYVE_ASL_COMPILER (path to iasl) is located through `which` and falls back to the previous path if not found. You can also pass a custom path through ENV (`IASL=/tmp/foo make`).

This is an improvement of #43.