### PR TITLE
Adds option to create master/slave pseudo-terminals when adding LPC devices.

### DIFF
--- a/include/xhyve/uart_emul.h
+++ b/include/xhyve/uart_emul.h
@@ -39,4 +39,4 @@ struct uart_softc *uart_init(uart_intr_func_t intr_assert,
 int uart_legacy_alloc(int unit, int *ioaddr, int *irq);
 uint8_t uart_read(struct uart_softc *sc, int offset);
 void uart_write(struct uart_softc *sc, int offset, uint8_t value);
-int uart_set_backend(struct uart_softc *sc, const char *opt);
+int uart_set_backend(struct uart_softc *sc, const char *backend, const char *devname);

--- a/src/pci_uart.c
+++ b/src/pci_uart.c
@@ -86,6 +86,7 @@ static int
 pci_uart_init(struct pci_devinst *pi, char *opts)
 {
 	struct uart_softc *sc;
+	char *name;
 
 	pci_emul_alloc_bar(pi, 0, PCIBAR_IO, UART_IO_BAR_SIZE);
 	pci_lintr_request(pi);
@@ -98,12 +99,14 @@ pci_uart_init(struct pci_devinst *pi, char *opts)
 	sc = uart_init(pci_uart_intr_assert, pci_uart_intr_deassert, pi);
 	pi->pi_arg = sc;
 
-	if (uart_set_backend(sc, opts) != 0) {
-		fprintf(stderr, "Unable to initialize backend '%s' for "
-		    "pci uart at %d:%d\n", opts, pi->pi_slot, pi->pi_func);
+	asprintf(&name, "pci uart at %d:%d", pi->pi_slot, pi->pi_func);
+	if (uart_set_backend(sc, opts, name) != 0) {
+		fprintf(stderr, "Unable to initialize backend '%s' for %s\n", opts, name);
+		free(name);
 		return (-1);
 	}
 
+	free(name);
 	return (0);
 }
 

--- a/src/uart_emul.c
+++ b/src/uart_emul.c
@@ -611,14 +611,14 @@ uart_init(uart_intr_func_t intr_assert, uart_intr_func_t intr_deassert,
 }
 
 static int
-uart_tty_backend(struct uart_softc *sc, const char *opts)
+uart_tty_backend(struct uart_softc *sc, const char *backend)
 {
 	int fd;
 	int retval;
 
 	retval = -1;
 
-	fd = open(opts, O_RDWR | O_NONBLOCK);
+	fd = open(backend, O_RDWR | O_NONBLOCK);
 	if (fd > 0 && isatty(fd)) {
 		sc->tty.fd = fd;
 		sc->tty.opened = true;
@@ -629,7 +629,7 @@ uart_tty_backend(struct uart_softc *sc, const char *opts)
 }
 
 int
-uart_set_backend(struct uart_softc *sc, const char *opts)
+uart_set_backend(struct uart_softc *sc, const char *backend, const char *devname)
 {
 	int retval;
 	int ptyfd;
@@ -637,15 +637,15 @@ uart_set_backend(struct uart_softc *sc, const char *opts)
 
 	retval = -1;
 
-	if (opts == NULL)
+	if (backend == NULL)
 		return (0);
 
-	if (strcmp("stdio", opts) == 0 && !uart_stdio) {
+	if (strcmp("stdio", backend) == 0 && !uart_stdio) {
 		sc->tty.fd = STDIN_FILENO;
 		sc->tty.opened = true;
 		uart_stdio = true;
 		retval = fcntl(sc->tty.fd, F_SETFL, O_NONBLOCK);
-	} else if (strcmp("autopty", opts) == 0) {
+	} else if (strcmp("autopty", backend) == 0) {
 		if ((ptyfd = open("/dev/ptmx", O_RDWR | O_NONBLOCK)) == -1) {
 			fprintf(stderr, "error opening /dev/ptmx char device");
 			return retval;
@@ -666,12 +666,12 @@ uart_set_backend(struct uart_softc *sc, const char *opts)
 			return retval;
 		}
 
-		fprintf(stdout, "Hook up a terminal emulator to %s in order to access your VM\n", ptyname);
+		fprintf(stdout, "%s connected to %s\n", devname, ptyname);
 		sc->tty.fd = ptyfd;
 		sc->tty.name = ptyname;
 		sc->tty.opened = true;
 		retval = 0;
-	} else if (uart_tty_backend(sc, opts) == 0) {
+	} else if (uart_tty_backend(sc, backend) == 0) {
 		retval = 0;
 	}
 

--- a/src/uart_emul.c
+++ b/src/uart_emul.c
@@ -90,6 +90,7 @@ struct fifo {
 struct ttyfd {
 	bool	opened;
 	int	fd;		/* tty device file descriptor */
+	char *name; /* slave pty name when using autopty*/
 	struct termios tio_orig, tio_new;    /* I/O Terminals */
 };
 
@@ -330,11 +331,11 @@ uart_drain(int fd, enum ev_type ev, void *arg)
 	struct uart_softc *sc;
 	int ch;
 
-	sc = arg;	
+	sc = arg;
 
 	assert(fd == sc->tty.fd);
 	assert(ev == EVF_READ);
-	
+
 	/*
 	 * This routine is called in the context of the mevent thread
 	 * to take out the softc lock to protect against concurrent
@@ -362,7 +363,7 @@ uart_write(struct uart_softc *sc, int offset, uint8_t value)
 	uint8_t msr;
 
 	pthread_mutex_lock(&sc->mtx);
-	
+
 	/*
 	 * Take care of the special case DLAB accesses first
 	 */
@@ -371,7 +372,7 @@ uart_write(struct uart_softc *sc, int offset, uint8_t value)
 			sc->dll = value;
 			goto done;
 		}
-		
+
 		if (offset == REG_DLH) {
 			sc->dlh = value;
 			goto done;
@@ -501,7 +502,7 @@ uart_read(struct uart_softc *sc, int offset)
 			reg = sc->dll;
 			goto done;
 		}
-		
+
 		if (offset == REG_DLH) {
 			reg = sc->dlh;
 			goto done;
@@ -519,7 +520,7 @@ uart_read(struct uart_softc *sc, int offset)
 		iir = (sc->fcr & FCR_ENABLE) ? IIR_FIFO_MASK : 0;
 
 		intr_reason = (uint8_t) uart_intr_reason(sc);
-			
+
 		/*
 		 * Deal with side effects of reading the IIR register
 		 */
@@ -623,7 +624,7 @@ uart_tty_backend(struct uart_softc *sc, const char *opts)
 		sc->tty.opened = true;
 		retval = 0;
 	}
-	    
+
 	return (retval);
 }
 
@@ -631,26 +632,48 @@ int
 uart_set_backend(struct uart_softc *sc, const char *opts)
 {
 	int retval;
+	int ptyfd;
+	char *ptyname;
 
 	retval = -1;
 
 	if (opts == NULL)
 		return (0);
 
-	if (strcmp("stdio", opts) == 0) {
-		if (!uart_stdio) {
-			sc->tty.fd = STDIN_FILENO;
-			sc->tty.opened = true;
-			uart_stdio = true;
-			retval = 0;
+	if (strcmp("stdio", opts) == 0 && !uart_stdio) {
+		sc->tty.fd = STDIN_FILENO;
+		sc->tty.opened = true;
+		uart_stdio = true;
+		retval = fcntl(sc->tty.fd, F_SETFL, O_NONBLOCK);
+	} else if (strcmp("autopty", opts) == 0) {
+		if ((ptyfd = open("/dev/ptmx", O_RDWR | O_NONBLOCK)) == -1) {
+			fprintf(stderr, "error opening /dev/ptmx char device");
+			return retval;
 		}
+
+		if ((ptyname = ptsname(ptyfd)) == NULL) {
+			perror("ptsname: error getting name for slave pseudo terminal");
+			return retval;
+		}
+
+		if ((retval = grantpt(ptyfd)) == -1) {
+			perror("error setting up ownership and permissions on slave pseudo terminal");
+			return retval;
+		}
+
+		if ((retval = unlockpt(ptyfd)) == -1) {
+			perror("error unlocking slave pseudo terminal, to allow its usage");
+			return retval;
+		}
+
+		fprintf(stdout, "Hook up a terminal emulator to %s in order too access your VM\n", ptyname);
+		sc->tty.fd = ptyfd;
+		sc->tty.name = ptyname;
+		sc->tty.opened = true;
+		retval = 0;
 	} else if (uart_tty_backend(sc, opts) == 0) {
 		retval = 0;
 	}
-
-	/* Make the backend file descriptor non-blocking */
-	if (retval == 0)
-		retval = fcntl(sc->tty.fd, F_SETFL, O_NONBLOCK);
 
 	if (retval == 0)
 		uart_opentty(sc);

--- a/src/uart_emul.c
+++ b/src/uart_emul.c
@@ -666,7 +666,7 @@ uart_set_backend(struct uart_softc *sc, const char *opts)
 			return retval;
 		}
 
-		fprintf(stdout, "Hook up a terminal emulator to %s in order too access your VM\n", ptyname);
+		fprintf(stdout, "Hook up a terminal emulator to %s in order to access your VM\n", ptyname);
 		sc->tty.fd = ptyfd;
 		sc->tty.name = ptyname;
 		sc->tty.opened = true;

--- a/src/xhyve.c
+++ b/src/xhyve.c
@@ -135,7 +135,7 @@ usage(int code)
 		"       -g: gdb port\n"
 		"       -h: help\n"
 		"       -H: vmexit from the guest on hlt\n"
-		"       -l: LPC device configuration\n"
+		"       -l: LPC device configuration. Ex: -l com1,stdio -l com2,autopty -l com2,/dev/myownpty\n"
 		"       -m: memory size in MB\n"
 		"       -M: print MAC address and exit if using vmnet\n"
 		"       -p: pin 'vcpu' to 'hostcpu'\n"


### PR DESCRIPTION
Enables to easily access xhyve guests through serial terminals. Demo: https://cldup.com/enMVXo6vKA.gif

For those unfamiliar with ptmx, there is a great explanation at http://unix.stackexchange.com/a/120018/128551