### PR TITLE
Use strlcpy() instead of strncpy() because subsequent mkstemps expects the string be nul-terminated.

### DIFF
--- a/src/acpi.c
+++ b/src/acpi.c
@@ -445,7 +445,7 @@ basl_fwrite_fadt(FILE *fp)
 	EFPRINTF(fp, "[0008]\t\tAddress : 00000000%08X\n",
 	    PM1A_EVT_ADDR);
 	EFPRINTF(fp, "\n");
-	
+
 	EFPRINTF(fp,
 	    "[0012]\t\tPM1B Event Block : [Generic Address Structure]\n");
 	EFPRINTF(fp, "[0001]\t\tSpace ID : 01 [SystemIO]\n");
@@ -650,7 +650,7 @@ basl_fwrite_facs(FILE *fp)
 	EFFLUSH(fp);
 
 	return (0);
-	
+
 err_exit:
 	return (errno);
 }
@@ -793,10 +793,10 @@ basl_open(struct basl_fio *bf, int suffix)
 	err = 0;
 
 	if (suffix) {
-		strncpy(bf->f_name, basl_stemplate, MAXPATHLEN);
+		strlcpy(bf->f_name, basl_stemplate, MAXPATHLEN);
 		bf->fd = mkstemps(bf->f_name, strlen(BHYVE_ASL_SUFFIX));
 	} else {
-		strncpy(bf->f_name, basl_template, MAXPATHLEN);
+		strlcpy(bf->f_name, basl_template, MAXPATHLEN);
 		bf->fd = mkstemp(bf->f_name);
 	}
 
@@ -853,7 +853,7 @@ basl_load(int fd, uint64_t off)
 
 	if (fstat(fd, &sb) < 0)
 		return (errno);
-		
+
 	gaddr = paddr_guest2host(basl_acpi_base + off, ((size_t) sb.st_size));
 	if (gaddr == NULL)
 		return (EFAULT);
@@ -889,7 +889,7 @@ basl_compile(int (*fwrite_section)(FILE *), uint64_t offset)
 			fmt = basl_verbose_iasl ?
 				"%s -p %s %s" :
 				"/bin/sh -c \"%s -p %s %s\" 1> /dev/null";
-				
+
 			snprintf(iaslbuf, sizeof(iaslbuf),
 				 fmt,
 				 BHYVE_ASL_COMPILER,
@@ -919,9 +919,9 @@ basl_make_templates(void)
 	int len;
 
 	err = 0;
-	
+
 	/*
-	 * 
+	 *
 	 */
 	if ((tmpdir = getenv("BHYVE_TMPDIR")) == NULL || *tmpdir == '\0' ||
 	    (tmpdir = getenv("TMPDIR")) == NULL || *tmpdir == '\0') {


### PR DESCRIPTION
Back ports recent change from bhyve.
