### PR TITLE
Add option to print MAC address and exit

### DIFF
--- a/include/xhyve/xhyve.h
+++ b/include/xhyve/xhyve.h
@@ -41,6 +41,7 @@
 #define	VMEXIT_ABORT (-1)
 
 extern int guest_ncpus;
+extern int print_mac;
 extern char *guest_uuid_str;
 extern char *vmname;
 

--- a/src/pci_virtio_net_vmnet.c
+++ b/src/pci_virtio_net_vmnet.c
@@ -722,6 +722,14 @@ pci_vtnet_init(struct pci_devinst *pi, UNUSED char *opts)
 		return (-1);
 	}
 
+    if (print_mac == 1)
+    {
+		printf("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
+			sc->vms->mac[0], sc->vms->mac[1], sc->vms->mac[2],
+			sc->vms->mac[3], sc->vms->mac[4], sc->vms->mac[5]);
+		exit(0);
+    }
+
 	sc->vsc_config.mac[0] = sc->vms->mac[0];
 	sc->vsc_config.mac[1] = sc->vms->mac[1];
 	sc->vsc_config.mac[2] = sc->vms->mac[2];

--- a/src/xhyve.c
+++ b/src/xhyve.c
@@ -78,6 +78,7 @@ extern int vmexit_task_switch(struct vm_exit *, int *vcpu);
 char *vmname = "vm";
 
 int guest_ncpus;
+int print_mac;
 char *guest_uuid_str;
 
 static int guest_vmexit_on_hlt, guest_vmexit_on_pause;
@@ -124,7 +125,7 @@ usage(int code)
 {
 
         fprintf(stderr,
-                "Usage: %s [-behuwxACHPWY] [-c vcpus] [-g <gdb port>] [-l <lpc>]\n"
+                "Usage: %s [-behuwxMACHPWY] [-c vcpus] [-g <gdb port>] [-l <lpc>]\n"
 		"       %*s [-m mem] [-p vcpu:hostcpu] [-s <pci>] [-U uuid] -f <fw>\n"
 		"       -A: create ACPI tables\n"
 		"       -c: # cpus (default 1)\n"
@@ -136,6 +137,7 @@ usage(int code)
 		"       -H: vmexit from the guest on hlt\n"
 		"       -l: LPC device configuration\n"
 		"       -m: memory size in MB\n"
+		"       -M: print MAC address and exit if using vmnet\n"
 		"       -p: pin 'vcpu' to 'hostcpu'\n"
 		"       -P: vmexit from the guest on pause\n"
 		"       -s: <slot,driver,configinfo> PCI slot config\n"
@@ -787,12 +789,13 @@ main(int argc, char *argv[])
 	progname = basename(argv[0]);
 	gdb_port = 0;
 	guest_ncpus = 1;
+	print_mac = 0;
 	memsize = 256 * MB;
 	mptgen = 1;
 	rtc_localtime = 1;
 	fw = 0;
 
-	while ((c = getopt(argc, argv, "behvuwxACHPWY:f:g:c:s:m:l:U:")) != -1) {
+	while ((c = getopt(argc, argv, "behvuwxMACHPWY:f:g:c:s:m:l:U:")) != -1) {
 		switch (c) {
 		case 'A':
 			acpi = 1;
@@ -831,6 +834,9 @@ main(int argc, char *argv[])
 			error = parse_memsize(optarg, &memsize);
 			if (error)
 				errx(EX_USAGE, "invalid memsize '%s'", optarg);
+			break;
+		case 'M':
+			print_mac = 1;
 			break;
 		case 'H':
 			guest_vmexit_on_hlt = 1;


### PR DESCRIPTION
As the name suggests, this adds the -M command line flag that will tell Xhyve to print the MAC address and exit if using vmnet.

This only really has practical use if the -U flag is also supplied with a UUID, so that you can determine which MAC address the UUID will map to. This will allow you to determine the IP address of the guest by inspecting the DHCP leases on the host. The idea being you run xhyve first with the -M flag to figure out ahead of time the MAC and IP address it will get, and then run it for real without the -M flag.

A similar pattern is used by [docker-machine-xhyve](https://github.com/zchee/docker-machine-driver-xhyve/tree/master/vmnet), and the nearly identical [xhyve-ruby native extension](https://github.com/dalehamel/xhyve-ruby/blob/master/ext/vmnet/vmnet.c) that each take the approach of spinning up a network interface just to find out what it's MAC address will be.

The side effect of doing this outside of Xhyve is that the binary performing the lookup has the same 'sudo' problem as outlined in https://github.com/mist64/xhyve/issues/60. So, if Xhyve were signed or xhyve had SetUID, it can more securely perform the lookup.

I tried to follow the existing style and idioms, and I'm open to any command line flag (-M seemed somewhat sensible). If there is another simpler or better way to achieve this, I'm open to it.

@mist64 for review